### PR TITLE
Normalize git repository sub-directories

### DIFF
--- a/mash/BitbakeRecipe.py
+++ b/mash/BitbakeRecipe.py
@@ -250,15 +250,9 @@ RDEPENDS:${PN} += \"${ROS_EXEC_DEPENDS}\"\n\
         lines.append(f'ROS_BRANCH ?= "branch={self.branch}"')
         lines.append(f'SRC_URI = "{self.src_uri}"')
         lines.append(f'SRCREV = "{self.srcrev}"')
+
         # XXX: Only use WORKDIR for older Yocto releases like scarthgap
-
-        split_path = self.pkg_path.split(os.path.sep)
-        if len(split_path) > 2:
-            git_subdir = os.path.sep + os.path.join(*split_path[2:])
-        else:
-            git_subdir = ""
-
-        lines.append(f'S = "${{WORKDIR}}/git{git_subdir}"')
+        lines.append(f'S = "${{WORKDIR}}/git{self.pkg_path}"')
 
         lines.append("")
         lines.append(f"ROS_BUILD_TYPE = \"{self.build_type}\"")


### PR DESCRIPTION
The vcstool can check out the git working copy in subdirectories that aren't directly under the src directory.

This means that the path to the ROS package in the workspace may not reflect the path that bitbake would use to build the recipe.

This creates the relative path by discovering the root of the git repository and using it as the base directory.

This should resolve issues #5 

Both the case where the package.xml is in a sub-directory:

src/mygroup/
   - .git
   - mypkg/
      - package.xml

as well as cases where the git repo is in a subdir:

src/mygroup/
   - mypkg/
      - .git
      - package.xml
